### PR TITLE
Remove link to closed Liberapay account

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
             <li><a href="download.html">Download</a></li>
             <li><a href="contact.html">Contact</a></li>
             <li><a href="https://github.com/pr-starfighter/starfighter">Project Page</a></li>
-            <li><a href="https://liberapay.com/diligentcircle/">Liberapay</a></li>
             <li><a href="https://www.patreon.com/diligentcircle">Patreon</a></li>
         </ul>
     </nav>


### PR DESCRIPTION
If the account won't be reopened, I would remove the link.